### PR TITLE
Answer count on the front page.

### DIFF
--- a/home/templates/home_templates/home.html
+++ b/home/templates/home_templates/home.html
@@ -3,7 +3,7 @@
 
 {% block frontpage %}
   {% for x in question_list %}
-    {{ x }}
+    {{ x }} | Answers: {{ x.answers }}
     <hr>
   {% endfor %}
 {% endblock %}


### PR DESCRIPTION
> Answers contributed to a question are now shown on the front page, beside each question.